### PR TITLE
only consider words that contain less than 3 vowels

### DIFF
--- a/wordle.go
+++ b/wordle.go
@@ -31,6 +31,8 @@ import (
 //       EARIOTNSLCUDPMHGBFYWKVXZJQ
 // rusty --R--T-S--U-------Y-------
 
+const AEIOUY = uint(1 << 24| 1 << 25 | 1 << 22 | 1 << 21 | 1 << 15 | 1 << 7) // A, E, I, O, U, Y
+
 var EARIOTNSLCUDPMHGBFYWKVXZJQ = [27]uint32{
 	0,
 	1 << 24, // A
@@ -88,8 +90,11 @@ func appendWords(filename string) {
 		raw := scanner.Text()
 		if len(raw) == 5 {
 			letters := encodeWord(raw)
-			if bits.OnesCount(uint(letters)) == 5 {
-				words = append(words, Word{raw, letters})
+			lettersAsUInt := uint(letters)
+			if bits.OnesCount(lettersAsUInt) == 5 {
+			    if bits.OnesCount(lettersAsUInt & AEIOUY ) < 3 {
+			        words = append(words, Word{raw, letters})
+			    }
 			}
 		}
 	}
@@ -107,7 +112,7 @@ func main() {
 	// Uncomment the following 2 lines to find 10 solutions:
 	appendWords("wordle-nyt-answers-alphabetical.txt")
 	appendWords("wordle-nyt-allowed-guesses.txt")
-	lenWords := len(words) // 8310
+	lenWords := len(words) // 7244
 
 	// xstrngr: "Your outer loop can be restricted to words with q or x   [q or j]
 	//           when these run out, you can't have a solution with the remaining 24 letters"


### PR DESCRIPTION
Reduces the words by roughly 1k to 7244
A,E,I,O,U,Y are regarded as vowels

if a word has more than 2 vowels, we would need a word with 5 unique characters that doesn't have any vowels in one of the other 5 words

## Benchmarks
`hyperfine --warmup 3 --runs 100 .\wordle.exe`

Before changes:
```
Benchmark 1: .\wordle.exe
  Time (mean ± σ):     152.6 ms ±   7.7 ms    [User: 2.0 ms, System: 42.8 ms]
  Range (min … max):   135.8 ms … 173.1 ms    100 runs
```
After changes:
```
Benchmark 1: .\wordle.exe
  Time (mean ± σ):     118.6 ms ±   6.2 ms    [User: 2.1 ms, System: 36.7 ms]
  Range (min … max):   111.2 ms … 137.2 ms    100 runs
```

